### PR TITLE
refactor(impressum): hardcode isGerman to true for simplicity

### DIFF
--- a/src/app/impressum/page.tsx
+++ b/src/app/impressum/page.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import { useLanguage } from "@/providers/language";
 import Link from "next/link";
 
 export default function ImpressumPage() {
-	const { language } = useLanguage();
-
-	const isGerman = language === "de";
+	const isGerman = true;
 
 	return (
 		<>


### PR DESCRIPTION
The language check was removed and `isGerman` was hardcoded to `true` to simplify the logic, as the page is only used in German.